### PR TITLE
扩展插件设置功能

### DIFF
--- a/src/components/settings/components/plugin/hooks/plugin.ts
+++ b/src/components/settings/components/plugin/hooks/plugin.ts
@@ -278,7 +278,6 @@ export const usePlugin = () => {
     if (!props?.REQUIRE || Object.keys(props.REQUIRE).length < 1) {
       return;
     }
-    // pluginSettingForm.value = {};
     pluginSettingForm.value = props.REQUIRE;
     pluginSettingId.value = id;
     pluginSettingName.value = props.NAME;
@@ -299,6 +298,7 @@ export const usePlugin = () => {
         continue;
       }
       // pluginSettingForm.value[key] = item[key] || '';
+
       // 设置配置值，如果为空使用默认值
       // 如果是新版插件
       if (isNewerVersionPlugin(pluginSettingForm.value[key])) {
@@ -306,7 +306,7 @@ export const usePlugin = () => {
       }
       // 为兼容旧版插件
       else {
-        pluginSettingForm.value[key] = item[key].toString() || ''
+        pluginSettingForm.value[key] = item[key] || ''
       }
     }
     pluginSettingWindow.value?.show();
@@ -317,7 +317,6 @@ export const usePlugin = () => {
       return;
     }
 
-    // 为兼容旧插件，检查插件设置项内容类型
     // 生成要保存的键值对
     let keys: Record<string, string> = {};
     pluginSettingFormKeys.value.forEach((key) => {

--- a/src/components/settings/components/plugin/hooks/plugin.ts
+++ b/src/components/settings/components/plugin/hooks/plugin.ts
@@ -13,6 +13,7 @@ import { showOpenFileDialog } from '../../../../../core/utils/file';
 import { useReadAloudStore } from '../../../../../store/read-aloud';
 import axios from '../../../../../core/axios';
 import { sleep } from '../../../../../core/utils/timer';
+import { RequireItem } from '../../../../../core/plugins/defined/plugins';
 
 export type Plugin = {
   enable: boolean
@@ -24,7 +25,8 @@ export type Plugin = {
   updating: boolean
   searchIndex: string
   builtIn: boolean
-  require?: Record<string, string>
+  // require?: Record<string, string>
+  require?: Record<string, RequireItem>
 }
 
 export const usePlugin = () => {
@@ -266,7 +268,8 @@ export const usePlugin = () => {
   }
 
   const pluginSettingWindow = ref<WindowEvent>();
-  const pluginSettingForm = ref<Record<string, string>>({});
+  // const pluginSettingForm = ref<Record<string, string>>({});
+  const pluginSettingForm = ref<Record<string, RequireItem>>({});
   const pluginSettingFormKeys = ref<string[]>([]);
   const pluginSettingName = ref('');
   const pluginSettingId = ref('');
@@ -275,17 +278,22 @@ export const usePlugin = () => {
     if (!props?.REQUIRE || Object.keys(props.REQUIRE).length < 1) {
       return;
     }
-    pluginSettingForm.value = {};
+    // pluginSettingForm.value = {};
+    pluginSettingForm.value = props.REQUIRE;
     pluginSettingId.value = id;
     pluginSettingName.value = props.NAME;
     pluginSettingFormKeys.value = Object.keys(props.REQUIRE);
     for (const key of pluginSettingFormKeys.value) {
-      pluginSettingForm.value[key] = '';
+      // pluginSettingForm.value[key] = '';
+      // 初始化配置为默认值
+      pluginSettingForm.value[key].value = pluginSettingForm.value[key].default;
       const item = getRequire(id);
       if (!item) {
         continue;
       }
-      pluginSettingForm.value[key] = item[key] || '';
+      // pluginSettingForm.value[key] = item[key] || '';
+      // 设置配置值，如果为空使用默认值
+      pluginSettingForm.value[key].value = item[key] || pluginSettingForm.value[key].default;
     }
     pluginSettingWindow.value?.show();
   }
@@ -294,7 +302,14 @@ export const usePlugin = () => {
     if (!pluginSettingId.value) {
       return;
     }
-    setRequire(pluginSettingId.value.trim(), cloneByJSON(pluginSettingForm.value));
+    // 生成要保存的键值对
+    let keys: Record<string, string> = {};
+    pluginSettingFormKeys.value.forEach((key) => {
+      keys[key] = pluginSettingForm.value[key].value
+    })
+    // setRequire(pluginSettingId.value.trim(), cloneByJSON(pluginSettingForm.value));
+    // 保存配置
+    setRequire(pluginSettingId.value.trim(), cloneByJSON(keys));
     pluginSettingWindow.value?.hide();
   }
 

--- a/src/components/settings/components/plugin/index.vue
+++ b/src/components/settings/components/plugin/index.vue
@@ -9,6 +9,9 @@ import {
   ElPagination,
   ElPopover,
   ElTag,
+  ElSwitch,
+  ElSelect,
+  ElOption,
 } from 'element-plus';
 import SettingsCard from '../card/index.vue';
 import SettingsCardItem from '../card/item/index.vue';
@@ -165,12 +168,23 @@ export default {
           <CloseButton @click="pluginSettingWindow?.hide()" />
         </header>
         <main class="rc-scrollbar">
-          <ul>
+          <!--<ul>
             <li v-for="key of pluginSettingFormKeys" :key="key">
               <Text ellipsis max-width="120" :title="key">{{ key }}</Text>
               <ElInput v-model="pluginSettingForm[key]" :placeholder="`请输入${key}`" />
             </li>
-          </ul>
+          </ul>-->
+          <template v-for="key in pluginSettingFormKeys">
+            <SettingsCardItem v-memo="[pluginSettingForm[key]]" :title="pluginSettingForm[key].label" :help="pluginSettingForm[key].description" class="plugin-setting-item">
+              <ElSwitch v-if="pluginSettingForm[key].type=='boolean'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder"/>
+              <ElInput v-else-if="pluginSettingForm[key].type=='string'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder"/>
+              <ElInputNumber v-else-if="pluginSettingForm[key].type=='number'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder" :min="0" :max="100" :step="1"/>
+              <ElSelect v-else-if="pluginSettingForm[key].type=='list'" v-model="pluginSettingForm[key].value">
+                <ElOption v-for="(option, _index) in pluginSettingForm[key].data" :label="option.name" :value="option.id"/>
+              </ElSelect>
+              <ElInput v-else-if="pluginSettingForm[key].type=='password'" type="password" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder" show-password/>
+            </SettingsCardItem>  
+          </template>
         </main>
         <footer>
           <ElButton type="primary" @click="settingPluginRequire">保存</ElButton>
@@ -316,6 +330,66 @@ export default {
       padding-right: 10px;
       .el-button {
         width: 100%;
+      }
+    }
+  }
+}
+
+.plugin-setting-item {
+  height: 30px;
+  font-size: 14px;
+  width: calc(100% - 10px);
+
+  .el-input {
+    height: 30px;
+    font-size: 14px;
+    width: 180px;
+
+    .el-input__wrapper {
+      cursor: default;
+
+      .el-input__inner {
+        height: 20px !important;
+      }
+
+      * {
+        cursor: default;
+      }
+    }
+  }
+
+  .el-select {
+    height: 30px;
+    font-size: 14px;
+    width: 180px;
+
+    .el-input__wrapper {
+      cursor: default;
+
+      .el-input__inner {
+        height: 20px !important;
+      }
+
+      * {
+        cursor: default;
+      }
+    }
+  }
+
+  .el-input-number {
+    height: 30px;
+    font-size: 14px;
+    width: 180px;
+
+    .el-input__wrapper {
+      cursor: default;
+
+      .el-input__inner {
+        height: 20px !important;
+      }
+
+      * {
+        cursor: default;
       }
     }
   }

--- a/src/components/settings/components/plugin/index.vue
+++ b/src/components/settings/components/plugin/index.vue
@@ -175,18 +175,18 @@ export default {
               <ElInput v-model="pluginSettingForm[key]" :placeholder="`请输入${key}`" />
             </li>
           </ul>-->
-          <template v-for="key in pluginSettingFormKeys">
-            <SettingsCardItem v-if="isNewerVersionPlugin(pluginSettingForm[key])" v-memo="[pluginSettingForm[key]]" :title="pluginSettingForm[key].label" :help="pluginSettingForm[key].description" class="plugin-setting-item">
-              <ElSwitch v-if="pluginSettingForm[key].type=='boolean'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder"/>
-              <ElInput v-else-if="pluginSettingForm[key].type=='string'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder"/>
-              <ElInputNumber v-else-if="pluginSettingForm[key].type=='number'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder" :min="0" :max="100" :step="1"/>
+          <template v-for="(key, index) in pluginSettingFormKeys">
+            <SettingsCardItem v-if="isNewerVersionPlugin(pluginSettingForm[key])" :title="pluginSettingForm[key].label" :help="pluginSettingForm[key].description" class="plugin-setting-item">
+              <ElSwitch v-if="pluginSettingForm[key].type=='boolean'" v-model="pluginSettingForm[key].value"/>
+              <ElInput v-else-if="pluginSettingForm[key].type=='string'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder ?? `请输入 ${pluginSettingForm[key].label}`"/>
+              <ElInputNumber v-else-if="pluginSettingForm[key].type=='number'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder ?? `请输入 ${pluginSettingForm[key].label}`" :min="1" :max="100" :step="1"/>
               <ElSelect v-else-if="pluginSettingForm[key].type=='list'" v-model="pluginSettingForm[key].value">
                 <ElOption v-for="(option, _index) in pluginSettingForm[key].data" :label="option.name" :value="option.id"/>
               </ElSelect>
-              <ElInput v-else-if="pluginSettingForm[key].type=='password'" type="password" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder" show-password/>
+              <ElInput v-else-if="pluginSettingForm[key].type=='password'" type="password" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder ?? `请输入 ${pluginSettingForm[key].label}`" show-password/>
             </SettingsCardItem>
-            <SettingsCardItem v-else v-memo="[pluginSettingForm[key]]" :title="key" class="plugin-setting-item">
-              <ElInput v-model="pluginSettingForm[key]" :placeholder="pluginSettingForm[key]"/>
+            <SettingsCardItem v-else :title="key" :key="index" class="plugin-setting-item">
+              <ElInput v-model="pluginSettingForm[key]" :placeholder="`请输入 ${key}`"/>
             </SettingsCardItem>
           </template>
         </main>

--- a/src/components/settings/components/plugin/index.vue
+++ b/src/components/settings/components/plugin/index.vue
@@ -29,6 +29,7 @@ import { Window, FileDrag, Text, CloseButton } from '../../../../components';
 import { usePluginDevtools } from './hooks/plugin-devtools';
 import { useDefaultSearch } from '../../../../hooks/default-search';
 import { useDefaultPagination } from '../../../../hooks/default-pagination';
+import { isNewerVersionPlugin } from '../../../../core/is';
 
 const { pluginDevtools, readAloud } = useSettingsStore();
 const {
@@ -175,7 +176,7 @@ export default {
             </li>
           </ul>-->
           <template v-for="key in pluginSettingFormKeys">
-            <SettingsCardItem v-memo="[pluginSettingForm[key]]" :title="pluginSettingForm[key].label" :help="pluginSettingForm[key].description" class="plugin-setting-item">
+            <SettingsCardItem v-if="isNewerVersionPlugin(pluginSettingForm[key])" v-memo="[pluginSettingForm[key]]" :title="pluginSettingForm[key].label" :help="pluginSettingForm[key].description" class="plugin-setting-item">
               <ElSwitch v-if="pluginSettingForm[key].type=='boolean'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder"/>
               <ElInput v-else-if="pluginSettingForm[key].type=='string'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder"/>
               <ElInputNumber v-else-if="pluginSettingForm[key].type=='number'" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder" :min="0" :max="100" :step="1"/>
@@ -183,7 +184,10 @@ export default {
                 <ElOption v-for="(option, _index) in pluginSettingForm[key].data" :label="option.name" :value="option.id"/>
               </ElSelect>
               <ElInput v-else-if="pluginSettingForm[key].type=='password'" type="password" v-model="pluginSettingForm[key].value" :placeholder="pluginSettingForm[key].placeholder" show-password/>
-            </SettingsCardItem>  
+            </SettingsCardItem>
+            <SettingsCardItem v-else v-memo="[pluginSettingForm[key]]" :title="key" class="plugin-setting-item">
+              <ElInput v-model="pluginSettingForm[key]" :placeholder="pluginSettingForm[key]"/>
+            </SettingsCardItem>
           </template>
         </main>
         <footer>

--- a/src/core/is/index.ts
+++ b/src/core/is/index.ts
@@ -1,4 +1,5 @@
 import NodeFormData from 'form-data';
+import { RequireItem } from '../plugins/defined/plugins';
 
 export const toStringCall = (val: any): string => {
   return Object.prototype.toString.call(val);
@@ -64,4 +65,8 @@ export const isKeyboardEvent = (val: any): val is KeyboardEvent => {
 export const getType = (val: any): string => {
   const str = toStringCall(val);
   return str.substring(1, str.length - 1).replace('object ', '');
+}
+/** 通过 REQUIRE 检查插件版本 */
+export const isNewerVersionPlugin = (val: RequireItem | string): val is RequireItem => {
+  return (val as RequireItem)?.label != undefined;
 }

--- a/src/core/is/index.ts
+++ b/src/core/is/index.ts
@@ -68,5 +68,10 @@ export const getType = (val: any): string => {
 }
 /** 通过 REQUIRE 检查插件版本 */
 export const isNewerVersionPlugin = (val: RequireItem | string): val is RequireItem => {
-  return (val as RequireItem)?.label != undefined;
+  // 不为空且有label
+  if(val && Object.hasOwn(val as unknown as RequireItem, 'label')){
+    return true;
+  }
+  return false;
+  // return val || Object.hasOwn(val as unknown as RequireItem, 'label') // (val as RequireItem)?.label != undefined);
 }

--- a/src/core/plugins/built-in/tts/aliyun.ts
+++ b/src/core/plugins/built-in/tts/aliyun.ts
@@ -1,5 +1,5 @@
 import { isNull, isUndefined } from '../../../is';
-import { PluginConstructorParams } from '../../defined/plugins';
+import { PluginConstructorParams, RequireItem } from '../../defined/plugins';
 import { EndCallback, NextCallback, TTSOptions, Voice } from '../../defined/ttsengine';
 import { chunkArray } from '../../../utils';
 import { createHmac } from 'crypto';
@@ -12,10 +12,36 @@ export class AliyunTTSEngine {
   public static readonly VERSION = '1.0.0';
   public static readonly VERSION_CODE = 0;
   public static readonly PLUGIN_FILE_URL = '';
-  public static readonly REQUIRE = {
-    AccessKeyId: '',
-    AccessKeySecret: '',
-    AppKey: '',
+  // public static readonly REQUIRE = {
+  //   AccessKeyId: '',
+  //   AccessKeySecret: '',
+  //   AppKey: '',
+  // };
+  public static readonly REQUIRE: Record<string, RequireItem> = {
+    AccessKeyId: {
+      type: 'string',
+      label: 'AccessKeyId',
+      value: '',
+      default: '',
+      placeholder: 'AccessKeyId',
+      description: '',
+    },
+    AccessKeySecret: {
+      type: 'string',
+      label: 'AccessKeySecret',
+      value: '',
+      default: '',
+      placeholder: 'AccessKeySecret',
+      description: '',
+    },
+    AppKey: {
+      type: 'string',
+      label: 'AppKey',
+      value: '',
+      default: '',
+      placeholder: 'AppKey',
+      description: '',
+    },
   };
 
   private store;
@@ -32,7 +58,7 @@ export class AliyunTTSEngine {
   }
   queryString() {
     const obj: Record<string, string> = {
-      AccessKeyId: AliyunTTSEngine.REQUIRE.AccessKeyId,
+      AccessKeyId: AliyunTTSEngine.REQUIRE.AccessKeyId.value,
       Action: 'CreateToken',
       Format: 'JSON',
       RegionId: 'cn-shanghai',
@@ -73,13 +99,13 @@ export class AliyunTTSEngine {
     }
   }
   async transform(texts: string[], options: TTSOptions, next: NextCallback, end: EndCallback): Promise<void> {
-    if (!AliyunTTSEngine.REQUIRE.AccessKeyId.trim()) {
+    if (!AliyunTTSEngine.REQUIRE.AccessKeyId.value.trim()) {
       return Promise.reject(new Error('未配置AccessKeyId'));
     }
-    if (!AliyunTTSEngine.REQUIRE.AccessKeySecret.trim()) {
+    if (!AliyunTTSEngine.REQUIRE.AccessKeySecret.value.trim()) {
       return Promise.reject(new Error('未配置AccessKeySecret'));
     }
-    if (!AliyunTTSEngine.REQUIRE.AppKey.trim()) {
+    if (!AliyunTTSEngine.REQUIRE.AppKey.value.trim()) {
       return Promise.reject(new Error('未配置AppKey'));
     }
     const {
@@ -109,7 +135,7 @@ export class AliyunTTSEngine {
           'X-NLS-Token': _token,
         },
         params: {
-          appkey: AliyunTTSEngine.REQUIRE.AppKey,
+          appkey: AliyunTTSEngine.REQUIRE.AppKey.value,
           text,
           token: _token,
           format: 'mp3',

--- a/src/core/plugins/built-in/tts/aliyun.ts
+++ b/src/core/plugins/built-in/tts/aliyun.ts
@@ -75,7 +75,7 @@ export class AliyunTTSEngine {
   }
   signature(queryString: string) {
     const stringToSign = this.stringToSign(queryString);
-    return createHmac('sha1', AliyunTTSEngine.REQUIRE.AccessKeySecret + '&').update(stringToSign).digest('base64');
+    return createHmac('sha1', AliyunTTSEngine.REQUIRE.AccessKeySecret.value + '&').update(stringToSign).digest('base64');
   }
   async getToken() {
     try {

--- a/src/core/plugins/built-in/tts/baidu.ts
+++ b/src/core/plugins/built-in/tts/baidu.ts
@@ -1,5 +1,5 @@
 import { isNull, isUndefined } from '../../../is';
-import { PluginConstructorParams } from '../../defined/plugins';
+import { PluginConstructorParams, RequireItem } from '../../defined/plugins';
 import { EndCallback, NextCallback, TTSOptions, Voice } from '../../defined/ttsengine';
 import { chunkArray } from '../../../utils';
 
@@ -11,9 +11,27 @@ export class BaiduTTSEngine {
   public static readonly VERSION = '1.0.0';
   public static readonly VERSION_CODE = 0;
   public static readonly PLUGIN_FILE_URL = '';
-  public static readonly REQUIRE = {
-    ApiKey: '',
-    SecretKey: ''
+  // public static readonly REQUIRE = {
+  //   ApiKey: '',
+  //   SecretKey: ''
+  // };
+  public static readonly REQUIRE: Record<string, RequireItem> = {
+    ApiKey: {
+      type: 'string',
+      label: 'ApiKey',
+      value: '',
+      default: '',
+      placeholder: 'ApiKey',
+      description: '',
+    },
+    SecretKey: {
+      type: 'string',
+      label: 'SecretKey',
+      value: '',
+      default: '',
+      placeholder: 'SecretKey',
+      description: '',
+    },
   };
 
   private store;
@@ -50,10 +68,10 @@ export class BaiduTTSEngine {
     }
   }
   async transform(texts: string[], options: TTSOptions, next: NextCallback, end: EndCallback): Promise<void> {
-    if (!BaiduTTSEngine.REQUIRE.ApiKey.trim()) {
+    if (!BaiduTTSEngine.REQUIRE.ApiKey.value.trim()) {
       return Promise.reject(new Error('未配置ApiKey'));
     }
-    if (!BaiduTTSEngine.REQUIRE.SecretKey.trim()) {
+    if (!BaiduTTSEngine.REQUIRE.SecretKey.value.trim()) {
       return Promise.reject(new Error('未配置SecretKey'));
     }
     const {

--- a/src/core/plugins/built-in/tts/baidu.ts
+++ b/src/core/plugins/built-in/tts/baidu.ts
@@ -46,7 +46,7 @@ export class BaiduTTSEngine {
   async getToken() {
     try {
       const now = Date.now();
-      const { body } = await this.request.post(`https://aip.baidubce.com/oauth/2.0/token?client_id=${BaiduTTSEngine.REQUIRE.ApiKey}&client_secret=${BaiduTTSEngine.REQUIRE.SecretKey}&grant_type=client_credentials`, {
+      const { body } = await this.request.post(`https://aip.baidubce.com/oauth/2.0/token?client_id=${BaiduTTSEngine.REQUIRE.ApiKey.value}&client_secret=${BaiduTTSEngine.REQUIRE.SecretKey.value}&grant_type=client_credentials`, {
         headers: {
           'content-type': 'application/json',
           accept: 'application/json'

--- a/src/core/plugins/defined/plugins.d.ts
+++ b/src/core/plugins/defined/plugins.d.ts
@@ -45,6 +45,23 @@ export type PluginConstructorParams = {
   uuid: (noDash?: boolean) => string
 }
 export type SearchFilter = boolean | ((entity: SearchEntity, searchKey: string, author?: string) => boolean);
+/** 插件设置项 */
+export type RequireItem = {
+  /** 要显示的标签 */
+  label: string
+  /** 字段类型 */
+  type: 'number' | 'string' | 'list' | 'password' | 'boolean'
+  /** 字段值 */
+  value?: any
+  /** 字段默认值 */
+  default: any
+  /** 列表类型的数据，ElSelect 的数据源格式 */
+  data?: any
+  /** 字段说明 */
+  description?: string
+  /**  字段输入提示 */
+  placeholder?: string
+}
 export interface PluginBaseProps {
   /**插件ID */
   readonly ID: PluginId;
@@ -63,7 +80,8 @@ export interface PluginBaseProps {
   /**书源、书城的请求链接 */
   readonly BASE_URL?: string;
   /**需要的参数 */
-  readonly REQUIRE?: Record<string, string>;
+  // readonly REQUIRE?: Record<string, string>;
+  readonly REQUIRE?: Record<string, RequireItem>;
   /**书源搜索结果过滤器 */
   readonly SEARCH_FILTER?: SearchFilter;
 }

--- a/src/core/plugins/defined/plugins.d.ts
+++ b/src/core/plugins/defined/plugins.d.ts
@@ -81,7 +81,7 @@ export interface PluginBaseProps {
   readonly BASE_URL?: string;
   /**需要的参数 */
   // readonly REQUIRE?: Record<string, string>;
-  readonly REQUIRE?: Record<string, RequireItem>;
+  readonly REQUIRE?: Record<string, RequireItem | string>;
   /**书源搜索结果过滤器 */
   readonly SEARCH_FILTER?: SearchFilter;
 }

--- a/src/core/plugins/index.ts
+++ b/src/core/plugins/index.ts
@@ -322,7 +322,8 @@ export class Plugins {
     if (cls.REQUIRE && require && Object.keys(require).length > 0) {
       for (const key of Object.keys(require)) {
         if (Object.hasOwn(cls.REQUIRE, key)) {
-          cls.REQUIRE[key] = require[key];
+          // cls.REQUIRE[key] = require[key];
+          cls.REQUIRE[key].value = require[key];
         }
       }
     }

--- a/src/core/plugins/index.ts
+++ b/src/core/plugins/index.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { chunkArray, errorHandler, newError } from '../utils';
-import { isArray, isDate, isFunction, isNull, isNumber, isString, isUndefined } from '../is';
+import { isArray, isDate, isFunction, isNewerVersionPlugin, isNull, isNumber, isString, isUndefined } from '../is';
 import { load } from 'cheerio';
 import { usePluginsStore } from '../../store/plugins';
 import { timeout, interval, sleep } from '../utils/timer';
@@ -19,7 +19,7 @@ import {
   PluginImportOptions,
   PluginInterface,
   PluginRequestConfig,
-  PluginsOptions
+  PluginsOptions,
 } from './defined/plugins';
 import { BookSource } from './defined/booksource';
 import { BookStore } from './defined/bookstore';
@@ -57,8 +57,6 @@ export namespace PluginType {
     return map.get(val);
   }
 }
-
-
 export class Plugins {
   private pluginsPool: Map<PluginId, {
     enable: boolean,
@@ -322,8 +320,15 @@ export class Plugins {
     if (cls.REQUIRE && require && Object.keys(require).length > 0) {
       for (const key of Object.keys(require)) {
         if (Object.hasOwn(cls.REQUIRE, key)) {
-          // cls.REQUIRE[key] = require[key];
-          cls.REQUIRE[key].value = require[key];
+          // cls.REQUIRE[key] = require[key]; 
+          // 如新是新版插件
+          if (isNewerVersionPlugin(cls.REQUIRE[key])) {
+            cls.REQUIRE[key].value = require[key];
+          }
+          // 兼容旧插件
+          else {
+            cls.REQUIRE[key] = require[key];
+          }
         }
       }
     }

--- a/src/core/plugins/index.ts
+++ b/src/core/plugins/index.ts
@@ -321,6 +321,7 @@ export class Plugins {
       for (const key of Object.keys(require)) {
         if (Object.hasOwn(cls.REQUIRE, key)) {
           // cls.REQUIRE[key] = require[key]; 
+          
           // 如新是新版插件
           if (isNewerVersionPlugin(cls.REQUIRE[key])) {
             cls.REQUIRE[key].value = require[key];

--- a/src/store/plugins.ts
+++ b/src/store/plugins.ts
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
 import { useMessage } from '../hooks/message';
 import { errorHandler } from '../core/utils';
-import { RequireItem } from '../core/plugins/defined/plugins';
 import { isNewerVersionPlugin } from '../core/is';
 
 export const usePluginsStore = defineStore('Plugins', {
@@ -32,12 +31,7 @@ export const usePluginsStore = defineStore('Plugins', {
         // Reflect.set(plugin.REQUIRE, key, val[key]);
         // 如果是新版插件
         if (isNewerVersionPlugin(plugin.REQUIRE[key])) {
-          // 获取配置项内容
-          let item = Reflect.get(plugin.REQUIRE, key);
-          // 修改配置值
-          (item as RequireItem).value = val[key];
-          // 更新配置项
-          Reflect.set(plugin.REQUIRE, key, item);
+          plugin.REQUIRE[key].value = val[key]
         }
         // 兼容旧版插件
         else {

--- a/src/store/plugins.ts
+++ b/src/store/plugins.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia';
 import { useMessage } from '../hooks/message';
 import { errorHandler } from '../core/utils';
-
+import { RequireItem } from '../core/plugins/defined/plugins';
+import { isNewerVersionPlugin } from '../core/is';
 
 export const usePluginsStore = defineStore('Plugins', {
   state: () => {
@@ -29,12 +30,19 @@ export const usePluginsStore = defineStore('Plugins', {
         }
         obj[key] = val[key];
         // Reflect.set(plugin.REQUIRE, key, val[key]);
-        // 获取配置项内容
-        let item = Reflect.get(plugin.REQUIRE, key);
-        // 修改配置值
-        if(item) item.value = val[key];
-        // 更新配置项
-        Reflect.set(plugin.REQUIRE, key, item);
+        // 如果是新版插件
+        if (isNewerVersionPlugin(plugin.REQUIRE[key])) {
+          // 获取配置项内容
+          let item = Reflect.get(plugin.REQUIRE, key);
+          // 修改配置值
+          (item as RequireItem).value = val[key];
+          // 更新配置项
+          Reflect.set(plugin.REQUIRE, key, item);
+        }
+        // 兼容旧版插件
+        else {
+          Reflect.set(plugin.REQUIRE, key, val[key]);
+        }
       }
       await GLOBAL_DB.store.pluginRequireStore.put({
         id: pid,

--- a/src/store/plugins.ts
+++ b/src/store/plugins.ts
@@ -28,7 +28,13 @@ export const usePluginsStore = defineStore('Plugins', {
           continue;
         }
         obj[key] = val[key];
-        Reflect.set(plugin.REQUIRE, key, val[key]);
+        // Reflect.set(plugin.REQUIRE, key, val[key]);
+        // 获取配置项内容
+        let item = Reflect.get(plugin.REQUIRE, key);
+        // 修改配置值
+        if(item) item.value = val[key];
+        // 更新配置项
+        Reflect.set(plugin.REQUIRE, key, item);
       }
       await GLOBAL_DB.store.pluginRequireStore.put({
         id: pid,


### PR DESCRIPTION
# 功能

扩展插件设置功能，并做了向下兼容。

在`src\core\plugins\defined\plugins.d.ts` 定义了 `type RequireItem `做为设置项的值扩展内容:
```typescript
export type RequireItem = {
  /** 要显示的标签 */
  label: string
  /** 字段类型 */
  type: 'number' | 'string' | 'list' | 'password' | 'boolean'
  /** 字段值 */
  value?: any
  /** 字段默认值 */
  default: any
  /** 列表类型的数据，ElSelect 的数据源格式 */
  data?: any
  /** 字段说明 */
  description?: string
  /**  字段输入提示 */
  placeholder?: string
}
```

说明：

- `label`：必填项，用于在设置界面做的设置项的标签显示
- `type`：必填项，用来确定设置项的值的的数据类型，在设置界面上显示不同的内容
  - `number`：数值型，在设置界面显示数值输入框
  - `string`：字符串型，在设置界面显示文本输入框
  - `list`：列表型，在设置界面显示下拉选择框，设置为`list`时，必须设置`data`
  - `password`：布尔型，在设置界面显示按钮
- `value`：设置项的值
- `default`：必填项，默认值，如果`value`为空，则默认使用`default`的值
- `description`：设置项的说明文本，鼠标移动到设置界面的问号图标上时显示。
- `placeholder`：提示文本，输入框的输入提示文本

## 插件开发

插件开发工具中书源插件的`REQUIRE`由原先的：

```typescript
public static readonly REQUIRE: Record<string, string> = { }
```
改为：

```typescript
/**
   * 静态属性 REQUIRE  可选
   * 要求用户填写的值
   */
  public static readonly REQUIRE: Record<string, {
    type: 'number' | 'string' | 'list' | 'password' | 'boolean', // 数据类型，用于在设置界面显示不同的样式
    label: string, // 标签内容，在设置界面显示的设置内容
    default: any, // 默认值，在设置界面留空时，默认使用的设置值
    value?: any, // 配置项的设置值，为空时使用默认值
    placeholder?: string, // 提示信息，在输入框中显示的提示信息
    description?: string, // 设置项的说明信息
    data?: [{ id: any, name: any }], // 下拉列表框的列表项
  }> = { }
```

同时向下兼容原来的

```typescript
public static readonly REQUIRE: Record<string, string> = { }
```

示例内容
```typescript
/**
   * 静态属性 REQUIRE  可选
   * 要求用户填写的值
   */
  public static readonly REQUIRE: Record<string, {
    type: 'number' | 'string' | 'list' | 'password' | 'boolean', // 数据类型，用于在设置界面显示不同的样式
    label: string, // 标签内容，在设置界面显示的设置内容
    default: any, // 默认值，在设置界面留空时，默认使用的设置值
    value?: any, // 配置项的设置值，为空时使用默认值
    placeholder?: string, // 提示信息，在输入框中显示的提示信息
    description?: string, // 设置项的说明信息
    data?: [{ id: any, name: any }], // 下拉列表框的列表项
  }> = {
      login:
      {
        type: 'boolean',
        label: '启用登录',
        default: false,
        placeholder: '登录书源',
        description: '启用或关闭登录书源的功能，在书源需要登录时才启用。启用时必须填写用户名和密码。',

      },
      username:
      {
        type: 'string',
        label: '用户名',
        default: '',
        placeholder: '填写书源的用户名',
        description: '用于登录书源的用户名，如果书源不需要登录，为非必填选项。',

      },
      password:
      {
        type: 'password',
        label: '密码',
        default: '',
        placeholder: '请填写书源的密码',
        description: '用于登录书源的密码，如果书源不需要登录，为非必填选项。',

      },
      maximumSearchResultPage:
      {
        type: 'number',
        label: '搜索页数',
        default: 1,
        placeholder: '请填写',
        description: '要返回的搜索结果页数，书源的搜索结果为50/页',

      },
      item2:
      {
        type: 'string',
        label: '测试项二',
        default: 0,
        placeholder: '请填写测试项二',
      },
      item3:
      {
        type: 'list',
        label: '测试项三',
        default: 1,
        data: [
          {
            id: 1,
            name: '选项一',
          },
          {
            id: 2,
            name: '选项二',
          },
          {
            id: 3,
            name: '选项三',
          },
        ],
        placeholder: '请填写测试项三',
        description: '设置项三为列表类型'
      },
    }
```

## 截图

示例代码中的插件设置界面
![示例代码中的插件设置界面](https://github.com/user-attachments/assets/4b77431c-3837-459d-9bc1-cfdae751f5c7)


兼容原先的插件设置功能]
![兼容原先的插件设置功能](https://github.com/user-attachments/assets/644eeadf-562c-42fc-a351-b34d1506cbcb)

TTS 插件设置界面
![Aliyun TTS Engine](https://github.com/user-attachments/assets/16983f49-7159-41e2-b1f9-b98c1362d678)
![Baidu TTS Engine](https://github.com/user-attachments/assets/b123c8e3-93dc-437f-922a-7a4b5933b23a)

