### PR TITLE
optimize: 优化超过最大行数时分章生成的章节名，提升最大行数上限

### DIFF
--- a/src/components/settings/components/txt-parse-rules/index.vue
+++ b/src/components/settings/components/txt-parse-rules/index.vue
@@ -60,7 +60,7 @@ export default {
     <SettingsCard title="配置">
       <SettingsCardItem title="最大行数">
         <ElInputNumber v-model="txtParse.maxLines" @change="cur => txtParse.maxLines = Math.floor(isUndefined(cur) ? 300 : cur)"
-          size="small" :value-on-clear="300" :min="100" :max="500" :step="1" />
+          size="small" :value-on-clear="300" :min="100" :max="10000" :step="1" />
       </SettingsCardItem>
     </SettingsCard>
     <SettingsCard :sticky="0">

--- a/src/core/book/txt-parser/worker/parse-chapter-content.ts
+++ b/src/core/book/txt-parser/worker/parse-chapter-content.ts
@@ -50,7 +50,7 @@ self.onmessage = e => {
         if (contents.length > maxLines) {
           const chunks = chunkArray(contents, maxLines);
           for (let j = 0; j < chunks.length; j++) {
-            let title: string = (j === 0 && chapterTitleList[i].trim()) ? chapterTitleList[i].trim() : `第${arr.length + 1}章`;
+            let title: string = chapterTitleList[i].trim() ? `${chapterTitleList[i].trim()}-${j+1}` : `第${arr.length + 1}章`;
             arr.push({
               title,
               contents: chunks[j]


### PR DESCRIPTION
1. 原本生成的章节名格式是「第 %d 章」，会打乱原本的生成的章节列表，调整为「原本的章节名-%d」这样的格式
2. 原本最大行数的上限是500，有一些超大章节可能超过 500 行，现在的 PC 性能应该也都足够渲染超长的章节，这里将上限调整到 10000